### PR TITLE
replace deprecated split() function call with explode()

### DIFF
--- a/include/controller-ping.php
+++ b/include/controller-ping.php
@@ -14,7 +14,7 @@
  header("Content-type: text/javascript;  charset=utf-8"); 
  
  if (isset($_SESSION['relaxx_hostdata'])) {
-   $config = split(";",$_SESSION['relaxx_hostdata'],3);
+   $config = explode(";",$_SESSION['relaxx_hostdata'],3);
    if ($config[2]=="") { $config[2]= null; }
    // include MPD-lib and connect
    require_once 'lib-mpd.php';

--- a/include/controller-playlist.php
+++ b/include/controller-playlist.php
@@ -52,16 +52,16 @@
     		($config->checkRights("add_songs") && $MPD->isCommand('add')) ? $MPD->addSong($_GET['value']) : $status = "error";
     		break;			
 		case 'swapSong':
-			$pos = split(":",$_GET['value']);
+			$pos = explode(":",$_GET['value']);
 			($config->checkRights("controll_playlist") && $MPD->isCommand('swap'))  ? $MPD->swapSong($pos[0],$pos[1]) : $status = "error";
     		break;			
 		case 'moveSong':
-			$pos = split(":",$_GET['value']);
+			$pos = explode(":",$_GET['value']);
 			($config->checkRights("controll_playlist") && $MPD->isCommand('move')) ? $MPD->moveSong($pos[0],$pos[1]) : $status = "error";
     		break;			
     	case 'deleteSong':
     		if (($config->checkRights("controll_playlist") && $MPD->isCommand('delete')) ) {
-    		  $ids = split(":",$_GET['value']);
+    		  $ids = explode(":",$_GET['value']);
     		  foreach ($ids as $id) { if ($id!="") $MPD->deleteSongId(intval($id));  }
 	        } else {
 			  $status = "error";


### PR DESCRIPTION
using split() messes up Apache's log file with warnings
